### PR TITLE
Last steps for the Stats Page 

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -26,6 +26,7 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import com.google.appengine.api.datastore.FetchOptions;
 
 /** Provides access to the data stored in Datastore. */
 public class Datastore {
@@ -78,5 +79,12 @@ public class Datastore {
     }
 
     return messages;
+  }
+
+  /** Returns the total number of messages for all users. */
+  public int getTotalMessageCount(){
+    Query query = new Query("Message");
+    PreparedQuery results = datastore.prepare(query);
+    return results.countEntities(FetchOptions.Builder.withLimit(1000));
   }
 }

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -1,0 +1,25 @@
+package com.google.codeu.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Responds with a hard-coded message for testing purposes.
+ */
+@WebServlet("/stats")
+
+
+public class StatsPageServlet extends HttpServlet{
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+
+        response.getOutputStream().println("hello world");
+    }
+}
+

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -7,19 +7,36 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.codeu.data.Datastore;
+import com.google.gson.JsonObject;
+
 /**
- * Responds with a hard-coded message for testing purposes.
+ * Handles fetching site statistics.
  */
 @WebServlet("/stats")
-
-
 public class StatsPageServlet extends HttpServlet{
 
+    private Datastore datastore;
+
+    @Override
+    public void init() {
+        datastore = new Datastore();
+    }
+
+    /**
+     * Responds with site statistics in JSON.
+     */
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
 
-        response.getOutputStream().println("hello world");
+        response.setContentType("application/json");
+
+        int messageCount = datastore.getTotalMessageCount();
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("messageCount", messageCount);
+        response.getOutputStream().println(jsonObject.toString());
     }
 }
 

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Stats</title>
+    <link rel="stylesheet" href="/css/main.css">
+
+    <script>
+    // Fetch stats and display them in the page.
+    function fetchStats(){
+      const url = '/stats';
+      fetch(url).then((response) => {
+        return response.json();
+      }).then((stats) => {
+        const statsContainer = document.getElementById('stats-container');
+        statsContainer.innerHTML = '';
+
+        const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
+        statsContainer.appendChild(messageCountElement);
+      });
+    }
+
+    function buildStatElement(statString){
+     const statElement = document.createElement('p');
+     statElement.appendChild(document.createTextNode(statString));
+     return statElement;
+    }
+
+    // Fetch data and populate the UI of the page.
+    function buildUI(){
+     fetchStats();
+    }
+  </script>
+</head>
+<body onload="buildUI()">
+<div id="content">
+    <h1>Site Statistics</h1>
+    <hr/>
+    <div id="stats-container">Loading...</div>
+</div>
+</body>
+</html>

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -36,7 +36,7 @@
     <h1>Site Statistics</h1>
     <hr/>
     <div id="stats-container">Loading...</div>
-    <img src="http://worldartsme.com/images/text-message-clipart-1.jpg">
+    <img src="http://clipart-library.com/image_gallery/464848.png">
 </div>
 </body>
 </html>

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -34,9 +34,9 @@
 <body onload="buildUI()">
 <div id="content">
     <h1>Site Statistics</h1>
-    <img src="http://worldartsme.com/images/text-message-clipart-1.jpg">
     <hr/>
     <div id="stats-container">Loading...</div>
+    <img src="http://worldartsme.com/images/text-message-clipart-1.jpg">
 </div>
 </body>
 </html>

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -34,6 +34,7 @@
 <body onload="buildUI()">
 <div id="content">
     <h1>Site Statistics</h1>
+    <img src="http://worldartsme.com/images/text-message-clipart-1.jpg">
     <hr/>
     <div id="stats-container">Loading...</div>
 </div>


### PR DESCRIPTION
Within this last commit, I created the stats.html page. It is an html page that fetches our user statistics from our server. This way our users don’t have to read our JSON data on the stats URL. Now, the stats URL (http://localhost:8080/stats.html) has “Site Statistics” as its header, and below shows the message count. 

I have attached an image of what it looks like now :) 

![screen shot 2019-03-03 at 7 15 44 pm](https://user-images.githubusercontent.com/13473746/53708536-c8ad0500-3de8-11e9-935e-3d0375f699a4.png)
